### PR TITLE
Make SVN::Look::proplist method work (fix regexp).

### DIFF
--- a/lib/SVN/Look.pm
+++ b/lib/SVN/Look.pm
@@ -501,7 +501,8 @@ sub proplist {
     my ($self, $path) = @_;
     unless ($self->{proplist}{$path}) {
         my $text = $self->_svnlook('proplist', '--verbose', $path);
-        my @list = split /^\s\s(\S+)\s:\s/m, $text;
+        my @list = split /^\s{2}(\S+)\n\s{4}/m, $text;
+
         shift @list;            # skip the leading empty field
         chomp(my %hash = @list);
         $self->{proplist}{$path} = \%hash;


### PR DESCRIPTION
Hi gnustavo,

SVN::Look fails its tests on my Mac running OS X 10.8.4, using the builtin svn (1.6.18) and the newer one that I built using homebrew (1.8.0).  I'm not sure if the output from `proplist --verbose` has changed since you wrote the code or....

In any case, I've updated the regexp that you use to split the output and it now Works For Me (tm).

It would be great if you could roll out a new release (with this fix or a better one...) so that out CI builds can Just Work (tm).

Thanks,

g.

---

The split in proplist should take output from svn proplist --verbose,
which looks like this on svn version 1.6 and 1.8:

---

Properties on 'foo':
  svn:mime-type
    text/plain
  svn:blarney
    text/plain

---

 and parse it into  list whose elements are:

---

Properties on 'foo':
svn:mime-type
text/plain
svn:blarney
text/plain

---

The method then goes on and discards the first element of the list and
the remaining are chomped and used to create the hash.
